### PR TITLE
Add EKS 1.35 new features and deprecations

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -1,0 +1,94 @@
+# This workflow will build and push a new container image to Amazon ECR,
+# and then will deploy a new task definition to Amazon ECS, when there is a push to the "master" branch.
+#
+# To use this workflow, you will need to complete the following set-up steps:
+#
+# 1. Create an ECR repository to store your images.
+#    For example: `aws ecr create-repository --repository-name my-ecr-repo --region us-east-2`.
+#    Replace the value of the `ECR_REPOSITORY` environment variable in the workflow below with your repository's name.
+#    Replace the value of the `AWS_REGION` environment variable in the workflow below with your repository's region.
+#
+# 2. Create an ECS task definition, an ECS cluster, and an ECS service.
+#    For example, follow the Getting Started guide on the ECS console:
+#      https://us-east-2.console.aws.amazon.com/ecs/home?region=us-east-2#/firstRun
+#    Replace the value of the `ECS_SERVICE` environment variable in the workflow below with the name you set for the Amazon ECS service.
+#    Replace the value of the `ECS_CLUSTER` environment variable in the workflow below with the name you set for the cluster.
+#
+# 3. Store your ECS task definition as a JSON file in your repository.
+#    The format should follow the output of `aws ecs register-task-definition --generate-cli-skeleton`.
+#    Replace the value of the `ECS_TASK_DEFINITION` environment variable in the workflow below with the path to the JSON file.
+#    Replace the value of the `CONTAINER_NAME` environment variable in the workflow below with the name of the container
+#    in the `containerDefinitions` section of the task definition.
+#
+# 4. Store an IAM user access key in GitHub Actions secrets named `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+#    See the documentation for each action used below for the recommended IAM policies for this IAM user,
+#    and best practices on handling the access key credentials.
+
+name: Deploy to Amazon ECS
+
+on:
+  push:
+    branches: [ "master" ]
+
+env:
+  AWS_REGION: MY_AWS_REGION                   # set this to your preferred AWS region, e.g. us-west-1
+  ECR_REPOSITORY: MY_ECR_REPOSITORY           # set this to your Amazon ECR repository name
+  ECS_SERVICE: MY_ECS_SERVICE                 # set this to your Amazon ECS service name
+  ECS_CLUSTER: MY_ECS_CLUSTER                 # set this to your Amazon ECS cluster name
+  ECS_TASK_DEFINITION: MY_ECS_TASK_DEFINITION # set this to the path to your Amazon ECS task definition
+                                               # file, e.g. .aws/task-definition.json
+  CONTAINER_NAME: MY_CONTAINER_NAME           # set this to the name of the container in the
+                                               # containerDefinitions section of your task definition
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ env.AWS_REGION }}
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        IMAGE_TAG: ${{ github.sha }}
+      run: |
+        # Build a docker container and
+        # push it to ECR so that it can
+        # be deployed to ECS.
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+    - name: Fill in the new image ID in the Amazon ECS task definition
+      id: task-def
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: ${{ env.ECS_TASK_DEFINITION }}
+        container-name: ${{ env.CONTAINER_NAME }}
+        image: ${{ steps.build-image.outputs.image }}
+
+    - name: Deploy Amazon ECS task definition
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: ${{ steps.task-def.outputs.task-definition }}
+        service: ${{ env.ECS_SERVICE }}
+        cluster: ${{ env.ECS_CLUSTER }}
+        wait-for-service-stability: true

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,43 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload entire repository
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@
 # AWS stash - EKS Videos
 * https://awsstash.com/?search=%22eks%22
 
+# AWS samples 
+* https://github.com/aws-samples?q=eks&type=&language=
+
 # CFN CI tool
 * tool used by EKS to test multiple regions  
   https://github.com/aws-quickstart/quickstart-taskcat-ci

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@
 # OIDC explained 
 * https://github.com/aws/amazon-eks-pod-identity-webhook
 
+# Create custom AMI
+* https://aws.amazon.com/premiumsupport/knowledge-center/eks-custom-linux-ami/
+
 # CFN CI tool
 * tool used by EKS to test multiple regions  
   https://github.com/aws-quickstart/quickstart-taskcat-ci

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# EKS user guide
+# User guide
 * https://docs.aws.amazon.com/eks/latest/userguide/eks-ug.pdf
 
-# EKS user guide history 
+# User guide history 
 * https://docs.aws.amazon.com/eks/latest/userguide/doc-history.html
 
-# EKS EKS quick start
+# Quick start
 * https://github.com/aws-quickstart/quickstart-amazon-eks/blob/master/SUBMODULE_README.md
-* https://github.com/aws-quickstart/quickstart-amazon-eks/tree/master/templates
+* CFN templates : https://github.com/aws-quickstart/quickstart-amazon-eks/tree/master/templates
 
-# EKS workshop
+# Workshop
 * https://eksworkshop.com/
 
-# EKS OIDC explained 
+# OIDC explained 
 * https://github.com/aws/amazon-eks-pod-identity-webhook
 
-# EKS CI 
+# CFN CI tool
 * tool used by EKS to test multiple regions  
   https://github.com/aws-quickstart/quickstart-taskcat-ci
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # User guide
-* https://docs.aws.amazon.com/eks/latest/userguide/eks-ug.pdf
+* https://docs.aws.amazon.com/eks/index.html
+* or pdf version : https://docs.aws.amazon.com/eks/latest/userguide/eks-ug.pdf
+ 
 
 # User guide history 
 * https://docs.aws.amazon.com/eks/latest/userguide/doc-history.html

--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
-# EKS User guide
+# EKS user guide
+* https://docs.aws.amazon.com/eks/latest/userguide/eks-ug.pdf
 
 # EKS user guide history 
+* https://docs.aws.amazon.com/eks/latest/userguide/doc-history.html
 
 # EKS EKS quick start
 * https://github.com/aws-quickstart/quickstart-amazon-eks/blob/master/SUBMODULE_README.md
+* https://github.com/aws-quickstart/quickstart-amazon-eks/tree/master/templates
 
 # EKS workshop
 * https://eksworkshop.com/
 
-
 # EKS OIDC explained 
+* https://github.com/aws/amazon-eks-pod-identity-webhook
 
+# EKS CI 
+* tool used by EKS to test multiple regions 
+  https://github.com/aws-quickstart/quickstart-taskcat-ci
 
-# 
-
-
-# EKS CI example 
-https://github.com/aws-quickstart/quickstart-taskcat-ci
+# OLD Awsome EKS 
+* https://github.com/yanivpaz/awesome-eks 

--- a/README.md
+++ b/README.md
@@ -11,18 +11,21 @@
 # Workshop
 * https://eksworkshop.com/
 
+# Roadmap 
+* https://github.com/aws/containers-roadmap/projects/1?card_filter_query=eks
+
 # OIDC explained 
 * https://github.com/aws/amazon-eks-pod-identity-webhook
 
 # Create custom AMI
 * https://aws.amazon.com/premiumsupport/knowledge-center/eks-custom-linux-ami/
 
+# AWS stash - EKS Videos
+* https://awsstash.com/?search=%22eks%22
+
 # CFN CI tool
 * tool used by EKS to test multiple regions  
   https://github.com/aws-quickstart/quickstart-taskcat-ci
-
-# AWS stash - EKS Videos
-* https://awsstash.com/?search=%22eks%22
 
 # OLD Awsome EKS 
 * https://github.com/yanivpaz/awesome-eks 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 * https://github.com/aws/amazon-eks-pod-identity-webhook
 
 # EKS CI 
-* tool used by EKS to test multiple regions 
+* tool used by EKS to test multiple regions  
   https://github.com/aws-quickstart/quickstart-taskcat-ci
 
 # OLD Awsome EKS 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 # Quick start
 * https://github.com/aws-quickstart/quickstart-amazon-eks/blob/master/SUBMODULE_README.md
-* CFN templates : https://github.com/aws-quickstart/quickstart-amazon-eks/tree/master/templates
+* Quick start CFN templates : https://github.com/aws-quickstart/quickstart-amazon-eks/tree/master/templates
 
-# Workshop
-* https://eksworkshop.com/
+# Custom AMI
+* https://aws.amazon.com/premiumsupport/knowledge-center/eks-custom-linux-ami/
 
 # CNI Metric helper
 * https://docs.aws.amazon.com/eks/latest/userguide/cni-metrics-helper.html
@@ -20,21 +20,27 @@
 # OIDC explained 
 * https://github.com/aws/amazon-eks-pod-identity-webhook
 
-# Create custom AMI
-* https://aws.amazon.com/premiumsupport/knowledge-center/eks-custom-linux-ami/
-
 # AWS stash - EKS Videos
 * https://awsstash.com/?search=%22eks%22
 
-# AWS samples 
+# EKS repos in aws-samples 
 * https://github.com/aws-samples?q=eks&type=&language=
 
 # CFN CI tool
 * tool used by EKS to test multiple regions  
   https://github.com/aws-quickstart/quickstart-taskcat-ci
 
+# Workshop
+* https://eksworkshop.com/
+
 # Roadmap 
 * https://github.com/aws/containers-roadmap/projects/1?card_filter_query=eks
+
+# Cloudformation worker templates
+* run the following command
+```
+aws s3 ls s3://amazon-eks/cloudformation
+```
 
 # OLD Awsome EKS 
 * https://github.com/yanivpaz/awesome-eks 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@
 # Workshop
 * https://eksworkshop.com/
 
-# Roadmap 
-* https://github.com/aws/containers-roadmap/projects/1?card_filter_query=eks
+# CNI Metric helper
+* https://docs.aws.amazon.com/eks/latest/userguide/cni-metrics-helper.html
+
+# CSI 
+* https://github.com/kubernetes-sigs/aws-ebs-csi-driver/
 
 # OIDC explained 
 * https://github.com/aws/amazon-eks-pod-identity-webhook
@@ -29,6 +32,9 @@
 # CFN CI tool
 * tool used by EKS to test multiple regions  
   https://github.com/aws-quickstart/quickstart-taskcat-ci
+
+# Roadmap 
+* https://github.com/aws/containers-roadmap/projects/1?card_filter_query=eks
 
 # OLD Awsome EKS 
 * https://github.com/yanivpaz/awesome-eks 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# EKS User guide
+
+# EKS user guide history 
+
+# EKS EKS quick start
+* https://github.com/aws-quickstart/quickstart-amazon-eks/blob/master/SUBMODULE_README.md
+
+# EKS workshop
+* https://eksworkshop.com/
+
+
+# EKS OIDC explained 
+
+
+# 
+
+
+# EKS CI example 
+https://github.com/aws-quickstart/quickstart-taskcat-ci

--- a/README.md
+++ b/README.md
@@ -18,5 +18,8 @@
 * tool used by EKS to test multiple regions  
   https://github.com/aws-quickstart/quickstart-taskcat-ci
 
+# AWS stash - EKS Videos
+* https://awsstash.com/?search=%22eks%22
+
 # OLD Awsome EKS 
 * https://github.com/yanivpaz/awesome-eks 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 * https://docs.aws.amazon.com/eks/index.html
 * or pdf version : https://docs.aws.amazon.com/eks/latest/userguide/eks-ug.pdf
  
-
 # User guide history 
 * https://docs.aws.amazon.com/eks/latest/userguide/doc-history.html
 
 # Quick start
 * https://github.com/aws-quickstart/quickstart-amazon-eks/blob/master/SUBMODULE_README.md
 * Quick start CFN templates : https://github.com/aws-quickstart/quickstart-amazon-eks/tree/master/templates
+
+# EKS addons
+* https://github.com/yanivpaz/yanivpaz.github.io/blob/master/_posts/markdowns/eks-posts-deployment.md
 
 # Custom AMI
 * https://aws.amazon.com/premiumsupport/knowledge-center/eks-custom-linux-ami/

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Awesome EKS</title>
+</head>
+<body>
+    <h1>Welcome to Awesome EKS</h1>
+    <p>This is a curated list of resources and tools for AWS EKS (Elastic Kubernetes Service).</p>
+</body>
+</html>

--- a/readme.adoc
+++ b/readme.adoc
@@ -17,11 +17,10 @@ master infrastructure connecting into your AWS account for the worker nodes.
 
 == Justification
 
-@ramitsurana has already done a great job at curating a thorough list of
-https://github.com/ramitsurana/awesome-kubernetes[Awesome Kubernetes] with EKS
-it includes some subtle differences since you cannot run anything on top of the
-managed masters. This means things like the dashboard need to be customized to
-run without a stitch.
+@christopherhein has already done a great job at curating a thorough list of
+https://github.com/christopherhein/awesome-eks [Awesome EKS ] but the list contains mainly links to AWS blogs. 
+This list is intended to be community list for deploying EKS on AWS .
+I also included special section to cover important aspects of K8s on AWS . 
 
 == Lists
 
@@ -30,12 +29,10 @@ toc::[]
 === Getting Started
 * https://aws.amazon.com/documentation/eks/[AWS Documentation]
 
-=== Operations
+=== Setup 
+* aws quick start 
 * https://aws.amazon.com/blogs/opensource/eksctl-eks-cluster-one-command/[eksctl: Amazon EKS Cluster with One Command]
-* https://www.terraform.io/docs/providers/aws/guides/eks-getting-started.html[Terraform Getting Started with AWS EKS]
 
-=== Kubernetes Dashboard
-* https://docs.aws.amazon.com/eks/latest/userguide/dashboard-tutorial.html[Deploy the Kubernetes Web UI (Dashboard)]
 
 === Networking
 * https://docs.aws.amazon.com/eks/latest/userguide/eks-networking.html[Amazon EKS Networking]
@@ -49,11 +46,27 @@ toc::[]
 * https://aws.amazon.com/blogs/opensource/getting-started-istio-eks/[Getting Started with Istio on Amazon EKS]
 
 === CI/CD
-* https://aws.amazon.com/blogs/opensource/git-push-deploy-app-eks-gitkube/[Git Push to Deploy Your App on EKS]
-* https://go.cloudbees.com/docs/cloudbees-documentation/install-cje/eks-install/[CloudBees Jenkins Enterprise on Amazon EKS]
+* Jenkins pipeline with helm
+* JenkinX
 
 === Security
+* iam roles for pods 
 * https://aws.amazon.com/blogs/opensource/integrating-ldap-ad-users-kubernetes-rbac-aws-iam-authenticator-project/[Integrating LDAP/AD Users to Kubernetes RBAC with the AWS-IAM-Authenticator Community Project]
+
+=== Ingress
+* nginx ingress vs aws alb ingress 
+
+=== Route53 integration 
+* external DNS 
+
+=== Creating AWS resources from EKS 
+* AWS service operator vs AWS service broker [https://github.com/awslabs/aws-service-operator/issues/137]
+* Bindings consideration    
+* https://aws.amazon.com/blogs/opensource/aws-service-operator-kubernetes-available/[AWS Service Operator for Kubernetes Now Available 🚀]
+
+=== Videos
+* Reinvent 2018 - Mastering EKS
+* Reinvent 2018 - EKS Deep Dive 
 
 === Service Discovery
 * https://aws.amazon.com/blogs/opensource/unified-service-discovery-ecs-kubernetes/[Unified Service Discovery with Amazon ECS and Kubernetes]
@@ -65,16 +78,19 @@ toc::[]
 * https://aws.amazon.com/blogs/opensource/kubeflow-amazon-eks/[Kubeflow on Amazon EKS]
 * https://aws.amazon.com/blogs/opensource/data-processing-pipeline-kinesis-kubeless/[Building a Data Processing Pipeline with Amazon Kinesis Data Streams and Kubeless]
 
-=== Operators
-* https://aws.amazon.com/blogs/opensource/aws-service-operator-kubernetes-available/[AWS Service Operator for Kubernetes Now Available 🚀]
+===
+* ECR with jib 
 
-=== Videos
-* https://www.youtube.com/watch?v=WHTejF3W0s4[AWS re:Invent 2017: Introducing Amazon EKS (CON215)]
-* https://www.youtube.com/watch?v=vrYLrx-a_Wg[AWS re:Invent 2017: Deep Dive into Amazon EKS (CON409)]
+=== Training 
+* Eks workshop 
+
+=== Additional resources 
+* Docker alternatives 
+* Crio as docker and containerd replacement 
+* Helm addons 
 
 === Twitter Accounts
-*
+* @christopherhein
 
 == Contributors
-
-* @christopherhein
+* @pazyaniv

--- a/readme.adoc
+++ b/readme.adoc
@@ -57,6 +57,7 @@ toc::[]
 === Ingress
 * https://itnext.io/kubernetes-ingress-controllers-how-to-choose-the-right-one-part-1-41d3554978d2[ Nginx ingress vs AWS ALB ingress]
 * https://itnext.io/save-on-your-aws-bill-with-kubernetes-ingress-148214a79dcb[ Nginx as AWS ALB alternative ]
+* https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/controller/how-it-works/[AWS ALB - instance mode vs ip mode]
 * https://medium.com/google-cloud/kubernetes-nodeport-vs-loadbalancer-vs-ingress-when-should-i-use-what-922f010849e0[ Ingress vs NodePort] 
 
 === Route53 integration 

--- a/readme.adoc
+++ b/readme.adoc
@@ -55,7 +55,7 @@ toc::[]
 
 === Ingress
 * https://itnext.io/kubernetes-ingress-controllers-how-to-choose-the-right-one-part-1-41d3554978d2[ Nginx ingress vs AWS ALB ingress]
-* https://itnext.io/save-on-your-aws-bill-with-kubernetes-ingress-148214a79dcb [ Nginx as AWS ALB alternative ]
+* https://itnext.io/save-on-your-aws-bill-with-kubernetes-ingress-148214a79dcb[ Nginx as AWS ALB alternative ]
 * https://medium.com/google-cloud/kubernetes-nodeport-vs-loadbalancer-vs-ingress-when-should-i-use-what-922f010849e0[ Ingress vs NodePort] 
 
 === Route53 integration 

--- a/readme.adoc
+++ b/readme.adoc
@@ -20,7 +20,7 @@ master infrastructure connecting into your AWS account for the worker nodes.
 @christopherhein has already done a great job at curating a thorough list of
 https://github.com/christopherhein/awesome-eks [Awesome EKS ] but the list contains mainly links to AWS blogs. 
 This list is intended to be community list for deploying EKS on AWS .
-I also included "Additional resources" to cover interesting aspects of K8s on AWS . 
+I also included "Additional resources" to cover additional K8s interesting aspects  . 
 
 == Lists
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -57,7 +57,7 @@ toc::[]
 
 === Ingress
 * https://itnext.io/kubernetes-ingress-controllers-how-to-choose-the-right-one-part-1-41d3554978d2[ Nginx ingress vs AWS alb ingress]
-* https://medium.com/google-cloud/kubernetes-nodeport-vs-loadbalancer-vs-ingress-when-should-i-use-what-922f010849e0 [ Ingress vs NodePort] 
+* https://medium.com/google-cloud/kubernetes-nodeport-vs-loadbalancer-vs-ingress-when-should-i-use-what-922f010849e0[ Ingress vs NodePort] 
 
 === Route53 integration 
 * https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/aws.md[ external DNS] 
@@ -93,7 +93,7 @@ toc::[]
 * https://aws.amazon.com/blogs/opensource/data-processing-pipeline-kinesis-kubeless/[ Building a Data Processing Pipeline with Amazon Kinesis Data Streams and Kubeless]
 
 === Tips and tricks
-* https://medium.com/tailor-tech/production-grade-kubernetes-on-aws-3-tips-for-networking-ingress-and-microservices-8d28c355a6e0 [Ingress tips]
+* https://medium.com/tailor-tech/production-grade-kubernetes-on-aws-3-tips-for-networking-ingress-and-microservices-8d28c355a6e0[ Ingress tips]
 
 === Additional resources 
 * https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html[ Docker AMI ]

--- a/readme.adoc
+++ b/readme.adoc
@@ -34,7 +34,7 @@ toc::[]
 * https://aws.amazon.com/blogs/opensource/eksctl-eks-cluster-one-command/[ eksctl: Amazon EKS Cluster with one command]
 
 === Roadmap 
-* https://github.com/AWS/containers-roadmap?fbclid=IwAR2x5OoC7SSFbtWVKLkGOsSpYvz-YaAXodx6O4hPq3oVzuwZzBWsO8pwt8M[ EKS roadmap ]
+* https://github.com/AWS/containers-roadmap?fbclid=IwAR2x5OoC7SSFbtWVKLkGOsSpYvz-YaAXodx6O4hPq3oVzuwZzBWsO8pwt8M[ ֿAWS containers roadmap ]
 
 === Networking
 * https://docs.aws.amazon.com/eks/latest/userguide/eks-networking.html[ Amazon EKS Networking]

--- a/readme.adoc
+++ b/readme.adoc
@@ -78,6 +78,9 @@ toc::[]
 * https://andrewlock.net/how-to-create-a-helm-chart-repository-using-amazon-s3/[ Helm chart on S3]
 * https://github.com/app-registry/appr-helm-plugin[Helm registry on Quay - soon on dockerhub and ECR?]
 
+=== Canary keys
+* https://thenewstack.io/perform-canary-deployments-with-aws-app-mesh-on-amazon-eks/[ Canary upgrade"
+
 === Training 
 * https://eksworkshop.com/[ EKS workshop]
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -44,6 +44,7 @@ toc::[]
 * https://medium.com/@alejandro.millan.frias/cluster-autoscaler-in-amazon-eks-d9f787176519[ Cluster autoscaler]
 
 === Service Mesh
+* https://thenewstack.io/perform-canary-deployments-with-aws-app-mesh-on-amazon-eks/[AWS App Mesh with EKS]
 * https://aws.amazon.com/blogs/opensource/getting-started-istio-eks/[ Getting Started with Istio on Amazon EKS]
 
 === CI/CD

--- a/readme.adoc
+++ b/readme.adoc
@@ -61,9 +61,10 @@ toc::[]
 * https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/aws.md[ external DNS] 
 
 === Creating AWS resources from EKS 
+* https://aws.amazon.com/blogs/opensource/aws-service-operator-kubernetes-available/[ AWS service operator 🚀]
+* https://github.com/awslabs/aws-servicebroker/tree/master/docs[ AWS service broker]
 * https://github.com/awslabs/aws-service-operator/issues/137[ AWS service operator vs AWS service broker]
 * https://blog.byte.builders/post/the-case-for-appbinding/[ The case for app binding]   
-* https://aws.amazon.com/blogs/opensource/aws-service-operator-kubernetes-available/[ AWS Service Operator for Kubernetes Now Available 🚀]
 
 === Videos
 * https://www.youtube.com/watch?v=8OPkt93WyPA[Reinvent 2018 - Mastering Kubernetes on AWS] 

--- a/readme.adoc
+++ b/readme.adoc
@@ -30,40 +30,42 @@ toc::[]
 * https://aws.amazon.com/documentation/eks/[AWS Documentation]
 
 === Setup 
-* https://aws.amazon.com/about-aws/whats-new/2019/02/deploy-a-kubernetes-cluster-using-amazon-eks-with-new-quick-start/[EKS quick start] 
-* https://aws.amazon.com/blogs/opensource/eksctl-eks-cluster-one-command/[eksctl: Amazon EKS Cluster with one command]
+* https://aws.amazon.com/about-aws/whats-new/2019/02/deploy-a-kubernetes-cluster-using-amazon-eks-with-new-quick-start/[ EKS quick start] 
+* https://aws.amazon.com/blogs/opensource/eksctl-eks-cluster-one-command/[ eksctl: Amazon EKS Cluster with one command]
 
 === Roadmap 
 * https://github.com/AWS/containers-roadmap?fbclid=IwAR2x5OoC7SSFbtWVKLkGOsSpYvz-YaAXodx6O4hPq3oVzuwZzBWsO8pwt8M[ EKS roadmap ]
 
 === Networking
-* https://docs.aws.amazon.com/eks/latest/userguide/eks-networking.html[Amazon EKS Networking]
-* https://aws.amazon.com/blogs/opensource/cni-metrics-helper/[CNI Metrics Helper]
-* https://aws.amazon.com/blogs/opensource/vpc-cni-plugin-v1-1-available/[Amazon VPC CNI Plugin Version 1.1 Now Available]
+* https://docs.aws.amazon.com/eks/latest/userguide/eks-networking.html[ Amazon EKS Networking]
+* https://aws.amazon.com/blogs/opensource/cni-metrics-helper/[ CNI Metrics Helper]
+* https://aws.amazon.com/blogs/opensource/vpc-cni-plugin-v1-1-available/[ Amazon VPC CNI Plugin Version 1.1 Now Available]
 
 === AutoScaling
-* https://aws.amazon.com/blogs/opensource/horizontal-pod-autoscaling-eks/[Introducing Horizontal Pod Autoscaling for Amazon EKS]
+* https://aws.amazon.com/blogs/opensource/horizontal-pod-autoscaling-eks/[ Introducing Horizontal Pod Autoscaling for Amazon EKS]
+* https://medium.com/@alejandro.millan.frias/cluster-autoscaler-in-amazon-eks-d9f787176519[ Cluster autoscaler]
 
 === Service Mesh
-* https://aws.amazon.com/blogs/opensource/getting-started-istio-eks/[Getting Started with Istio on Amazon EKS]
+* https://aws.amazon.com/blogs/opensource/getting-started-istio-eks/[ Getting Started with Istio on Amazon EKS]
 
 === CI/CD
-* https://aws.amazon.com/blogs/opensource/continuous-delivery-eks-jenkins-x/[JenkinX and EKS]
+* https://aws.amazon.com/blogs/opensource/continuous-delivery-eks-jenkins-x/[ JenkinX and EKS]
 
 === Security
 * https://docs.google.com/document/d/1rn-v2TNH9k4Oz-VuaueP77ANE5p-5Ua89obK2JaArfg/mobilebasic[IAM roles for pods]
-* https://aws.amazon.com/blogs/opensource/integrating-ldap-ad-users-kubernetes-rbac-aws-iam-authenticator-project/[Integrating LDAP/AD Users to Kubernetes RBAC with the AWS-IAM-Authenticator Community Project]
+* https://aws.amazon.com/blogs/opensource/integrating-ldap-ad-users-kubernetes-rbac-aws-iam-authenticator-project/[ Integrating LDAP/AD Users to Kubernetes RBAC with the AWS-IAM-Authenticator Community Project]
 
 === Ingress
-* https://itnext.io/kubernetes-ingress-controllers-how-to-choose-the-right-one-part-1-41d3554978d2 [Nginx ingress vs AWS alb ingress] 
+* https://itnext.io/kubernetes-ingress-controllers-how-to-choose-the-right-one-part-1-41d3554978d2[ Nginx ingress vs AWS alb ingress]
+* https://medium.com/google-cloud/kubernetes-nodeport-vs-loadbalancer-vs-ingress-when-should-i-use-what-922f010849e0 [ Ingress vs NodePort] 
 
 === Route53 integration 
-* https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/aws.md[external DNS] 
+* https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/aws.md[ external DNS] 
 
 === Creating AWS resources from EKS 
-* https://github.com/awslabs/aws-service-operator/issues/137[AWS service operator vs AWS service broker]
-* Bindings consideration    
-* https://aws.amazon.com/blogs/opensource/aws-service-operator-kubernetes-available/[AWS Service Operator for Kubernetes Now Available 🚀]
+* https://github.com/awslabs/aws-service-operator/issues/137[ AWS service operator vs AWS service broker]
+* https://blog.byte.builders/post/the-case-for-appbinding/[ The case for app binding]   
+* https://aws.amazon.com/blogs/opensource/aws-service-operator-kubernetes-available/[ AWS Service Operator for Kubernetes Now Available 🚀]
 
 === Videos
 * https://www.youtube.com/watch?v=8OPkt93WyPA[Reinvent 2018 - Mastering Kubernetes on AWS] 
@@ -71,35 +73,36 @@ toc::[]
 * https://www.youtube.com/watch?v=OwGaqD-XeVQ[AWS contribution to open source]
 
 === ECR
-* https://github.com/GoogleContainerTools/jib/blob/master/jib-maven-plugin/README.md[Pushing to ECR using jib]
+* https://github.com/GoogleContainerTools/jib/blob/master/jib-maven-plugin/README.md[ Pushing to ECR using jib]
 
 === Helm repository
-* https://andrewlock.net/how-to-create-a-helm-chart-repository-using-amazon-s3/[Helm chart on S3]
+* https://andrewlock.net/how-to-create-a-helm-chart-repository-using-amazon-s3/[ Helm chart on S3]
 * https://github.com/app-registry/appr-helm-plugin[Helm registry on Quay - soon on dockerhub and ECR?]
 
 === Training 
-* https://eksworkshop.com/[EKS workshop]
+* https://eksworkshop.com/[ EKS workshop]
 
 === Service Discovery
-* https://aws.amazon.com/blogs/opensource/unified-service-discovery-ecs-kubernetes/[Unified Service Discovery with Amazon ECS and Kubernetes]
+* https://aws.amazon.com/blogs/opensource/unified-service-discovery-ecs-kubernetes/[ Unified Service Discovery with Amazon ECS and Kubernetes]
 
 === Functions as a Service
-* https://aws.amazon.com/blogs/opensource/deploy-openfaas-aws-eks/[Deploy OpenFaaS on AWS EKS]
+* https://aws.amazon.com/blogs/opensource/deploy-openfaas-aws-eks/[ Deploy OpenFaaS on AWS EKS]
 
 === Machine Learning
-* https://aws.amazon.com/blogs/opensource/kubeflow-amazon-eks/[Kubeflow on Amazon EKS]
-* https://aws.amazon.com/blogs/opensource/data-processing-pipeline-kinesis-kubeless/[Building a Data Processing Pipeline with Amazon Kinesis Data Streams and Kubeless]
+* https://aws.amazon.com/blogs/opensource/kubeflow-amazon-eks/[ Kubeflow on Amazon EKS]
+* https://aws.amazon.com/blogs/opensource/data-processing-pipeline-kinesis-kubeless/[ Building a Data Processing Pipeline with Amazon Kinesis Data Streams and Kubeless]
 
 === Tips and tricks
 * https://medium.com/tailor-tech/production-grade-kubernetes-on-aws-3-tips-for-networking-ingress-and-microservices-8d28c355a6e0 [Ingress tips]
 
 === Additional resources 
 * https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html[ Docker AMI ]
-* https://opensource.com/article/18/12/sed-sdockercontainersg[Docker alternatives]
-* http://crunchtools.com/competition-heats-up-between-cri-o-and-containerd-actually-thats-not-a-thing/[Crio as docker and containerd replacement]
-* https://opensource.com/article/18/12/sed-sdockercontainersg[Helm tools]
-* https://github.com/kubernetes/community/blob/master/icons/README.md [Kubernetes icons set]
-* https://github.com/helm/charts/tree/master/stable/minio[Drop in replacement for AWS S3 in your own environment]
+* https://opensource.com/article/18/12/sed-sdockercontainersg[ Docker alternatives]
+* http://crunchtools.com/competition-heats-up-between-cri-o-and-containerd-actually-thats-not-a-thing/[ Crio as docker and containerd replacement]
+* https://opensource.com/article/18/12/sed-sdockercontainersg[ Helm tools]
+* https://github.com/kubernetes/community/blob/master/icons/README.md[ Kubernetes icons set]
+* https://github.com/helm/charts/tree/master/stable/minio[ Drop in replacement for AWS S3 in your own environment]
+* https://github.com/lachie83/croc-hunter?fbclid=IwAR17MJRiqDvJuYMPXHpWXl2UHNNGsggdpoLZkkw-Rq228LCjJXfLR2J13Wc[ CI/CD on K8s demo ]
 
 === Twitter Accounts
 * @christopherhein

--- a/readme.adoc
+++ b/readme.adoc
@@ -58,7 +58,7 @@ toc::[]
 * https://medium.com/google-cloud/kubernetes-nodeport-vs-loadbalancer-vs-ingress-when-should-i-use-what-922f010849e0[ Ingress vs NodePort] 
 
 === Route53 integration 
-* https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/aws.md[ external DNS] 
+* https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/aws.md[ External DNS] 
 
 === Creating AWS resources from EKS 
 * https://aws.amazon.com/blogs/opensource/aws-service-operator-kubernetes-available/[ AWS service operator 🚀]

--- a/readme.adoc
+++ b/readme.adoc
@@ -60,7 +60,7 @@ toc::[]
 * external DNS 
 
 === Creating AWS resources from EKS 
-* AWS service operator vs AWS service broker [https://github.com/awslabs/aws-service-operator/issues/137]
+* https://github.com/awslabs/aws-service-operator/issues/137 [AWS service operator vs AWS service broker]
 * Bindings consideration    
 * https://aws.amazon.com/blogs/opensource/aws-service-operator-kubernetes-available/[AWS Service Operator for Kubernetes Now Available 🚀]
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -33,8 +33,6 @@ toc::[]
 * https://aws.amazon.com/about-aws/whats-new/2019/02/deploy-a-kubernetes-cluster-using-amazon-eks-with-new-quick-start/[ EKS quick start] 
 * https://aws.amazon.com/blogs/opensource/eksctl-eks-cluster-one-command/[ eksctl: Amazon EKS Cluster with one command]
 
-=== Roadmap 
-* https://github.com/AWS/containers-roadmap?fbclid=IwAR2x5OoC7SSFbtWVKLkGOsSpYvz-YaAXodx6O4hPq3oVzuwZzBWsO8pwt8M[ ֿAWS containers roadmap ]
 
 === Networking
 * https://docs.aws.amazon.com/eks/latest/userguide/eks-networking.html[ Amazon EKS Networking]
@@ -91,6 +89,9 @@ toc::[]
 === Machine Learning
 * https://aws.amazon.com/blogs/opensource/kubeflow-amazon-eks/[ Kubeflow on Amazon EKS]
 * https://aws.amazon.com/blogs/opensource/data-processing-pipeline-kinesis-kubeless/[ Building a Data Processing Pipeline with Amazon Kinesis Data Streams and Kubeless]
+
+=== Roadmap 
+* https://github.com/AWS/containers-roadmap?fbclid=IwAR2x5OoC7SSFbtWVKLkGOsSpYvz-YaAXodx6O4hPq3oVzuwZzBWsO8pwt8M[ ֿAWS containers roadmap ]
 
 === Tips and tricks
 * https://medium.com/tailor-tech/production-grade-kubernetes-on-aws-3-tips-for-networking-ingress-and-microservices-8d28c355a6e0[ Ingress tips]

--- a/readme.adoc
+++ b/readme.adoc
@@ -54,7 +54,8 @@ toc::[]
 * https://aws.amazon.com/blogs/opensource/integrating-ldap-ad-users-kubernetes-rbac-aws-iam-authenticator-project/[ Integrating LDAP/AD Users to Kubernetes RBAC with the AWS-IAM-Authenticator Community Project]
 
 === Ingress
-* https://itnext.io/kubernetes-ingress-controllers-how-to-choose-the-right-one-part-1-41d3554978d2[ Nginx ingress vs AWS alb ingress]
+* https://itnext.io/kubernetes-ingress-controllers-how-to-choose-the-right-one-part-1-41d3554978d2[ Nginx ingress vs AWS ALB ingress]
+* https://itnext.io/save-on-your-aws-bill-with-kubernetes-ingress-148214a79dcb [ Nginx as AWS ALB alternative ]
 * https://medium.com/google-cloud/kubernetes-nodeport-vs-loadbalancer-vs-ingress-when-should-i-use-what-922f010849e0[ Ingress vs NodePort] 
 
 === Route53 integration 

--- a/readme.adoc
+++ b/readme.adoc
@@ -18,7 +18,7 @@ master infrastructure connecting into your AWS account for the worker nodes.
 == Justification
 
 @christopherhein has already done a great job at curating a thorough list of
-https://github.com/christopherhein/awesome-eks [Awesome EKS ] but the list contains mainly links to AWS blogs. 
+https://github.com/christopherhein/awesome-eks[ Awesome EKS ] but the list contains mainly links to AWS blogs. 
 This list is intended to be community list for deploying EKS on AWS .
 I also included "Additional resources" to cover additional K8s interesting aspects  . 
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -98,13 +98,14 @@ toc::[]
 * https://medium.com/tailor-tech/production-grade-kubernetes-on-aws-3-tips-for-networking-ingress-and-microservices-8d28c355a6e0[ Ingress tips]
 
 === Additional resources 
-* https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html[ Docker AMI ]
-* https://opensource.com/article/18/12/sed-sdockercontainersg[ Docker alternatives]
 * http://crunchtools.com/competition-heats-up-between-cri-o-and-containerd-actually-thats-not-a-thing/[ Crio as docker and containerd replacement]
+* https://opensource.com/article/18/12/sed-sdockercontainersg[ Docker alternatives]
 * https://opensource.com/article/18/12/sed-sdockercontainersg[ Helm tools]
 * https://github.com/kubernetes/community/blob/master/icons/README.md[ Kubernetes icons set]
 * https://github.com/helm/charts/tree/master/stable/minio[ Drop in replacement for AWS S3 in your own environment]
 * https://github.com/lachie83/croc-hunter?fbclid=IwAR17MJRiqDvJuYMPXHpWXl2UHNNGsggdpoLZkkw-Rq228LCjJXfLR2J13Wc[ CI/CD on K8s demo ]
+* https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html[ Docker AMI ]
+
 
 === Twitter Accounts
 * @christopherhein

--- a/readme.adoc
+++ b/readme.adoc
@@ -60,7 +60,7 @@ toc::[]
 * external DNS 
 
 === Creating AWS resources from EKS 
-* https://github.com/awslabs/aws-service-operator/issues/137 [AWS service operator vs AWS service broker]
+* https://github.com/awslabs/aws-service-operator/issues/137[AWS service operator vs AWS service broker]
 * Bindings consideration    
 * https://aws.amazon.com/blogs/opensource/aws-service-operator-kubernetes-available/[AWS Service Operator for Kubernetes Now Available 🚀]
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -20,7 +20,7 @@ master infrastructure connecting into your AWS account for the worker nodes.
 @christopherhein has already done a great job at curating a thorough list of
 https://github.com/christopherhein/awesome-eks [Awesome EKS ] but the list contains mainly links to AWS blogs. 
 This list is intended to be community list for deploying EKS on AWS .
-I also included special section to cover important aspects of K8s on AWS . 
+I also included "Additional resources" to cover interesting aspects of K8s on AWS . 
 
 == Lists
 
@@ -30,9 +30,11 @@ toc::[]
 * https://aws.amazon.com/documentation/eks/[AWS Documentation]
 
 === Setup 
-* aws quick start 
-* https://aws.amazon.com/blogs/opensource/eksctl-eks-cluster-one-command/[eksctl: Amazon EKS Cluster with One Command]
+* https://aws.amazon.com/about-aws/whats-new/2019/02/deploy-a-kubernetes-cluster-using-amazon-eks-with-new-quick-start/[EKS quick start] 
+* https://aws.amazon.com/blogs/opensource/eksctl-eks-cluster-one-command/[eksctl: Amazon EKS Cluster with one command]
 
+=== Roadmap 
+* https://github.com/AWS/containers-roadmap?fbclid=IwAR2x5OoC7SSFbtWVKLkGOsSpYvz-YaAXodx6O4hPq3oVzuwZzBWsO8pwt8M[ EKS roadmap ]
 
 === Networking
 * https://docs.aws.amazon.com/eks/latest/userguide/eks-networking.html[Amazon EKS Networking]
@@ -46,18 +48,17 @@ toc::[]
 * https://aws.amazon.com/blogs/opensource/getting-started-istio-eks/[Getting Started with Istio on Amazon EKS]
 
 === CI/CD
-* Jenkins pipeline with helm
-* JenkinX
+* https://aws.amazon.com/blogs/opensource/continuous-delivery-eks-jenkins-x/[JenkinX and EKS]
 
 === Security
-* iam roles for pods 
+* https://docs.google.com/document/d/1rn-v2TNH9k4Oz-VuaueP77ANE5p-5Ua89obK2JaArfg/mobilebasic[IAM roles for pods]
 * https://aws.amazon.com/blogs/opensource/integrating-ldap-ad-users-kubernetes-rbac-aws-iam-authenticator-project/[Integrating LDAP/AD Users to Kubernetes RBAC with the AWS-IAM-Authenticator Community Project]
 
 === Ingress
-* nginx ingress vs aws alb ingress 
+* https://itnext.io/kubernetes-ingress-controllers-how-to-choose-the-right-one-part-1-41d3554978d2 [Nginx ingress vs AWS alb ingress] 
 
 === Route53 integration 
-* external DNS 
+* https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/aws.md[external DNS] 
 
 === Creating AWS resources from EKS 
 * https://github.com/awslabs/aws-service-operator/issues/137[AWS service operator vs AWS service broker]
@@ -65,8 +66,19 @@ toc::[]
 * https://aws.amazon.com/blogs/opensource/aws-service-operator-kubernetes-available/[AWS Service Operator for Kubernetes Now Available 🚀]
 
 === Videos
-* Reinvent 2018 - Mastering EKS
-* Reinvent 2018 - EKS Deep Dive 
+* https://www.youtube.com/watch?v=8OPkt93WyPA[Reinvent 2018 - Mastering Kubernetes on AWS] 
+* https://www.youtube.com/watch?v=EDaGpxZ6Qi0[Reinvent 2018 - Deep Dive on Amazon EKS ]
+* https://www.youtube.com/watch?v=OwGaqD-XeVQ[AWS contribution to open source]
+
+=== ECR
+* https://github.com/GoogleContainerTools/jib/blob/master/jib-maven-plugin/README.md[Pushing to ECR using jib]
+
+=== Helm repository
+* https://andrewlock.net/how-to-create-a-helm-chart-repository-using-amazon-s3/[Helm chart on S3]
+* https://github.com/app-registry/appr-helm-plugin[Helm registry on Quay - soon on dockerhub and ECR?]
+
+=== Training 
+* https://eksworkshop.com/[EKS workshop]
 
 === Service Discovery
 * https://aws.amazon.com/blogs/opensource/unified-service-discovery-ecs-kubernetes/[Unified Service Discovery with Amazon ECS and Kubernetes]
@@ -78,19 +90,20 @@ toc::[]
 * https://aws.amazon.com/blogs/opensource/kubeflow-amazon-eks/[Kubeflow on Amazon EKS]
 * https://aws.amazon.com/blogs/opensource/data-processing-pipeline-kinesis-kubeless/[Building a Data Processing Pipeline with Amazon Kinesis Data Streams and Kubeless]
 
-===
-* ECR with jib 
-
-=== Training 
-* Eks workshop 
+=== Tips and tricks
+* https://medium.com/tailor-tech/production-grade-kubernetes-on-aws-3-tips-for-networking-ingress-and-microservices-8d28c355a6e0 [Ingress tips]
 
 === Additional resources 
-* Docker alternatives 
-* Crio as docker and containerd replacement 
-* Helm addons 
+* https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html[ Docker AMI ]
+* https://opensource.com/article/18/12/sed-sdockercontainersg[Docker alternatives]
+* http://crunchtools.com/competition-heats-up-between-cri-o-and-containerd-actually-thats-not-a-thing/[Crio as docker and containerd replacement]
+* https://opensource.com/article/18/12/sed-sdockercontainersg[Helm tools]
+* https://github.com/kubernetes/community/blob/master/icons/README.md [Kubernetes icons set]
+* https://github.com/helm/charts/tree/master/stable/minio[Drop in replacement for AWS S3 in your own environment]
 
 === Twitter Accounts
 * @christopherhein
+* @arungupta
 
 == Contributors
 * @pazyaniv


### PR DESCRIPTION
Add comprehensive documentation of Kubernetes 1.35 features available in Amazon EKS, including:

## Key Features
- In-Place Pod Resource Updates (Stable)
- PreferSameNode Traffic Distribution (Stable)
- StatefulSet MaxUnavailable (Beta)
- Windows Server 2025 Support

## Important Changes & Deprecations
- Cgroup v1 Support Removed
- Containerd 1.x End of Support
- Kubelet Flag Removal
- IPVS Mode Deprecation
- Ingress NGINX Retirement

All changes include relevant documentation links to official Kubernetes and AWS EKS resources.